### PR TITLE
Basic middleware system

### DIFF
--- a/__tests__/depth-limit-basics/output.ansi
+++ b/__tests__/depth-limit-basics/output.ansi
@@ -1,30 +1,30 @@
 FoFoF_fragments.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 3 > 2
+- [17:3] Self-reference limit for field 'User.friends' exceeded: 3 > 2
   Problematic paths:
   - FoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends
 
 FoFoF.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 3 > 2
+- [6:9] Self-reference limit for field 'User.friends' exceeded: 3 > 2
   Problematic paths:
   - FoFoF:query>currentUser>friends>friends>friends
 
 FoFoFoF_fragments.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 4 > 3
+- [22:3] Self-reference limit for field 'User.friends' exceeded: 4 > 3
   Problematic paths:
   - FoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends
 
 FoFoFoF.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 4 > 3
+- [7:11] Self-reference limit for field 'User.friends' exceeded: 4 > 3
   Problematic paths:
   - FoFoFoF:query>currentUser>friends>friends>friends>friends
 
 FoFoFoFoFoF_fragments.graphql:
-- Maximum list nesting depth limit exceeded: 6 > 5
+- [35:3] Maximum list nesting depth limit exceeded: 6 > 5
   Problematic paths:
   - FoFoFoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends>F5:User.friends>F6:User.friends
 
 FoFoFoFoFoF.graphql:
-- Maximum list nesting depth limit exceeded: 6 > 5
+- [9:15] Maximum list nesting depth limit exceeded: 6 > 5
   Problematic paths:
   - FoFoFoFoFoF:query>currentUser>friends>friends>friends>friends>friends>friends
 
@@ -41,16 +41,16 @@ Invalid_FoFoFoFoF_wide_cycle.graphql:
 - [9:5] Cannot spread fragment "F1" within itself via "F2", "F3", "F4", "F5".
 
 Self10_fragments.graphql:
-- Maximum selection depth limit exceeded: 11 > 10
+- [49:3] Maximum selection depth limit exceeded: 11 > 10
   Problematic paths:
   - Self10:query>currentUser>self>F1:User.self>F2:User.self>F3:User.self>F4:User.self>F5:User.self>F6:User.self>F7:User.self>F8:User.self>F9:User.self
 
 Self10.graphql:
-- Maximum selection depth limit exceeded: 11 > 10
+- [13:23] Maximum selection depth limit exceeded: 11 > 10
   Problematic paths:
   - Self10:query>currentUser>self>self>self>self>self>self>self>self>self>self
 
 SelfOtherSelf5.graphql:
-- Maximum selection depth limit exceeded: 11 > 10
+- [13:23] Maximum selection depth limit exceeded: 11 > 10
   Problematic paths:
   - SelfOtherSelf5:query>currentUser>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf

--- a/__tests__/depth-limit-basics/output.custom-baseline.ansi
+++ b/__tests__/depth-limit-basics/output.custom-baseline.ansi
@@ -1,25 +1,25 @@
 FoFoF.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 3 > 2
+- [6:9] Self-reference limit for field 'User.friends' exceeded: 3 > 2
   Problematic paths:
   - FoFoF:query>currentUser>friends>friends>friends
 
 FoFoFoF_fragments.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 4 > 3
+- [22:3] Self-reference limit for field 'User.friends' exceeded: 4 > 3
   Problematic paths:
   - FoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends
 
 FoFoFoF.graphql:
-- Self-reference limit for field 'User.friends' exceeded: 4 > 3
+- [7:11] Self-reference limit for field 'User.friends' exceeded: 4 > 3
   Problematic paths:
   - FoFoFoF:query>currentUser>friends>friends>friends>friends
 
 FoFoFoFoFoF_fragments.graphql:
-- Maximum list nesting depth limit exceeded: 6 > 5
+- [35:3] Maximum list nesting depth limit exceeded: 6 > 5
   Problematic paths:
   - FoFoFoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends>F5:User.friends>F6:User.friends
 
 FoFoFoFoFoF.graphql:
-- Maximum list nesting depth limit exceeded: 6 > 5
+- [9:15] Maximum list nesting depth limit exceeded: 6 > 5
   Problematic paths:
   - FoFoFoFoFoF:query>currentUser>friends>friends>friends>friends>friends>friends
 
@@ -36,16 +36,16 @@ Invalid_FoFoFoFoF_wide_cycle.graphql:
 - [9:5] Cannot spread fragment "F1" within itself via "F2", "F3", "F4", "F5".
 
 Self10_fragments.graphql:
-- Maximum selection depth limit exceeded: 11 > 10
+- [49:3] Maximum selection depth limit exceeded: 11 > 10
   Problematic paths:
   - Self10:query>currentUser>self>F1:User.self>F2:User.self>F3:User.self>F4:User.self>F5:User.self>F6:User.self>F7:User.self>F8:User.self>F9:User.self
 
 Self10.graphql:
-- Maximum selection depth limit exceeded: 11 > 10
+- [13:23] Maximum selection depth limit exceeded: 11 > 10
   Problematic paths:
   - Self10:query>currentUser>self>self>self>self>self>self>self>self>self>self
 
 SelfOtherSelf5.graphql:
-- Maximum selection depth limit exceeded: 11 > 10
+- [13:23] Maximum selection depth limit exceeded: 11 > 10
   Problematic paths:
   - SelfOtherSelf5:query>currentUser>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf

--- a/__tests__/depth-limit-basics/results.custom-baseline.json5
+++ b/__tests__/depth-limit-basics/results.custom-baseline.json5
@@ -29,10 +29,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 3 > 2",
+          locations: [
+            {
+              line: 6,
+              column: 9,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoF',
-          operationCoordinates: [
-            'FoFoF:query>currentUser>friends>friends>friends',
+          operations: [
+            {
+              operationName: 'FoFoF',
+              operationCoordinates: [
+                'FoFoF:query>currentUser>friends>friends>friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -55,10 +65,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 4 > 3",
+          locations: [
+            {
+              line: 22,
+              column: 3,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoFoF',
-          operationCoordinates: [
-            'FoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends',
+          operations: [
+            {
+              operationName: 'FoFoFoF',
+              operationCoordinates: [
+                'FoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -81,10 +101,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 4 > 3",
+          locations: [
+            {
+              line: 7,
+              column: 11,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoFoF',
-          operationCoordinates: [
-            'FoFoFoF:query>currentUser>friends>friends>friends>friends',
+          operations: [
+            {
+              operationName: 'FoFoFoF',
+              operationCoordinates: [
+                'FoFoFoF:query>currentUser>friends>friends>friends>friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -131,10 +161,20 @@
       errors: [
         {
           message: 'Maximum list nesting depth limit exceeded: 6 > 5',
+          locations: [
+            {
+              line: 35,
+              column: 3,
+            },
+          ],
           infraction: 'maxListDepth',
-          operationName: 'FoFoFoFoFoF',
-          operationCoordinates: [
-            'FoFoFoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends>F5:User.friends>F6:User.friends',
+          operations: [
+            {
+              operationName: 'FoFoFoFoFoF',
+              operationCoordinates: [
+                'FoFoFoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends>F5:User.friends>F6:User.friends',
+              ],
+            },
           ],
           override: {
             maxListDepth: 6,
@@ -155,10 +195,20 @@
       errors: [
         {
           message: 'Maximum list nesting depth limit exceeded: 6 > 5',
+          locations: [
+            {
+              line: 9,
+              column: 15,
+            },
+          ],
           infraction: 'maxListDepth',
-          operationName: 'FoFoFoFoFoF',
-          operationCoordinates: [
-            'FoFoFoFoFoF:query>currentUser>friends>friends>friends>friends>friends>friends',
+          operations: [
+            {
+              operationName: 'FoFoFoFoFoF',
+              operationCoordinates: [
+                'FoFoFoFoFoF:query>currentUser>friends>friends>friends>friends>friends>friends',
+              ],
+            },
           ],
           override: {
             maxListDepth: 6,
@@ -263,10 +313,20 @@
       errors: [
         {
           message: 'Maximum selection depth limit exceeded: 11 > 10',
+          locations: [
+            {
+              line: 49,
+              column: 3,
+            },
+          ],
           infraction: 'maxDepth',
-          operationName: 'Self10',
-          operationCoordinates: [
-            'Self10:query>currentUser>self>F1:User.self>F2:User.self>F3:User.self>F4:User.self>F5:User.self>F6:User.self>F7:User.self>F8:User.self>F9:User.self',
+          operations: [
+            {
+              operationName: 'Self10',
+              operationCoordinates: [
+                'Self10:query>currentUser>self>F1:User.self>F2:User.self>F3:User.self>F4:User.self>F5:User.self>F6:User.self>F7:User.self>F8:User.self>F9:User.self',
+              ],
+            },
           ],
           override: {
             maxDepth: 11,
@@ -287,10 +347,20 @@
       errors: [
         {
           message: 'Maximum selection depth limit exceeded: 11 > 10',
+          locations: [
+            {
+              line: 13,
+              column: 23,
+            },
+          ],
           infraction: 'maxDepth',
-          operationName: 'Self10',
-          operationCoordinates: [
-            'Self10:query>currentUser>self>self>self>self>self>self>self>self>self>self',
+          operations: [
+            {
+              operationName: 'Self10',
+              operationCoordinates: [
+                'Self10:query>currentUser>self>self>self>self>self>self>self>self>self>self',
+              ],
+            },
           ],
           override: {
             maxDepth: 11,
@@ -335,10 +405,20 @@
       errors: [
         {
           message: 'Maximum selection depth limit exceeded: 11 > 10',
+          locations: [
+            {
+              line: 13,
+              column: 23,
+            },
+          ],
           infraction: 'maxDepth',
-          operationName: 'SelfOtherSelf5',
-          operationCoordinates: [
-            'SelfOtherSelf5:query>currentUser>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf',
+          operations: [
+            {
+              operationName: 'SelfOtherSelf5',
+              operationCoordinates: [
+                'SelfOtherSelf5:query>currentUser>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf',
+              ],
+            },
           ],
           override: {
             maxDepth: 11,

--- a/__tests__/depth-limit-basics/results.json5
+++ b/__tests__/depth-limit-basics/results.json5
@@ -17,10 +17,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 3 > 2",
+          locations: [
+            {
+              line: 17,
+              column: 3,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoF',
-          operationCoordinates: [
-            'FoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends',
+          operations: [
+            {
+              operationName: 'FoFoF',
+              operationCoordinates: [
+                'FoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -43,10 +53,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 3 > 2",
+          locations: [
+            {
+              line: 6,
+              column: 9,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoF',
-          operationCoordinates: [
-            'FoFoF:query>currentUser>friends>friends>friends',
+          operations: [
+            {
+              operationName: 'FoFoF',
+              operationCoordinates: [
+                'FoFoF:query>currentUser>friends>friends>friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -69,10 +89,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 4 > 3",
+          locations: [
+            {
+              line: 22,
+              column: 3,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoFoF',
-          operationCoordinates: [
-            'FoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends',
+          operations: [
+            {
+              operationName: 'FoFoFoF',
+              operationCoordinates: [
+                'FoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -95,10 +125,20 @@
       errors: [
         {
           message: "Self-reference limit for field 'User.friends' exceeded: 4 > 3",
+          locations: [
+            {
+              line: 7,
+              column: 11,
+            },
+          ],
           infraction: "maxDepthByFieldCoordinates['User.friends']",
-          operationName: 'FoFoFoF',
-          operationCoordinates: [
-            'FoFoFoF:query>currentUser>friends>friends>friends>friends',
+          operations: [
+            {
+              operationName: 'FoFoFoF',
+              operationCoordinates: [
+                'FoFoFoF:query>currentUser>friends>friends>friends>friends',
+              ],
+            },
           ],
           override: {
             maxDepthByFieldCoordinates: {
@@ -145,10 +185,20 @@
       errors: [
         {
           message: 'Maximum list nesting depth limit exceeded: 6 > 5',
+          locations: [
+            {
+              line: 35,
+              column: 3,
+            },
+          ],
           infraction: 'maxListDepth',
-          operationName: 'FoFoFoFoFoF',
-          operationCoordinates: [
-            'FoFoFoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends>F5:User.friends>F6:User.friends',
+          operations: [
+            {
+              operationName: 'FoFoFoFoFoF',
+              operationCoordinates: [
+                'FoFoFoFoFoF:query>currentUser>F1:User.friends>F2:User.friends>F3:User.friends>F4:User.friends>F5:User.friends>F6:User.friends',
+              ],
+            },
           ],
           override: {
             maxListDepth: 6,
@@ -169,10 +219,20 @@
       errors: [
         {
           message: 'Maximum list nesting depth limit exceeded: 6 > 5',
+          locations: [
+            {
+              line: 9,
+              column: 15,
+            },
+          ],
           infraction: 'maxListDepth',
-          operationName: 'FoFoFoFoFoF',
-          operationCoordinates: [
-            'FoFoFoFoFoF:query>currentUser>friends>friends>friends>friends>friends>friends',
+          operations: [
+            {
+              operationName: 'FoFoFoFoFoF',
+              operationCoordinates: [
+                'FoFoFoFoFoF:query>currentUser>friends>friends>friends>friends>friends>friends',
+              ],
+            },
           ],
           override: {
             maxListDepth: 6,
@@ -277,10 +337,20 @@
       errors: [
         {
           message: 'Maximum selection depth limit exceeded: 11 > 10',
+          locations: [
+            {
+              line: 49,
+              column: 3,
+            },
+          ],
           infraction: 'maxDepth',
-          operationName: 'Self10',
-          operationCoordinates: [
-            'Self10:query>currentUser>self>F1:User.self>F2:User.self>F3:User.self>F4:User.self>F5:User.self>F6:User.self>F7:User.self>F8:User.self>F9:User.self',
+          operations: [
+            {
+              operationName: 'Self10',
+              operationCoordinates: [
+                'Self10:query>currentUser>self>F1:User.self>F2:User.self>F3:User.self>F4:User.self>F5:User.self>F6:User.self>F7:User.self>F8:User.self>F9:User.self',
+              ],
+            },
           ],
           override: {
             maxDepth: 11,
@@ -301,10 +371,20 @@
       errors: [
         {
           message: 'Maximum selection depth limit exceeded: 11 > 10',
+          locations: [
+            {
+              line: 13,
+              column: 23,
+            },
+          ],
           infraction: 'maxDepth',
-          operationName: 'Self10',
-          operationCoordinates: [
-            'Self10:query>currentUser>self>self>self>self>self>self>self>self>self>self',
+          operations: [
+            {
+              operationName: 'Self10',
+              operationCoordinates: [
+                'Self10:query>currentUser>self>self>self>self>self>self>self>self>self>self',
+              ],
+            },
           ],
           override: {
             maxDepth: 11,
@@ -349,10 +429,20 @@
       errors: [
         {
           message: 'Maximum selection depth limit exceeded: 11 > 10',
+          locations: [
+            {
+              line: 13,
+              column: 23,
+            },
+          ],
           infraction: 'maxDepth',
-          operationName: 'SelfOtherSelf5',
-          operationCoordinates: [
-            'SelfOtherSelf5:query>currentUser>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf',
+          operations: [
+            {
+              operationName: 'SelfOtherSelf5',
+              operationCoordinates: [
+                'SelfOtherSelf5:query>currentUser>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf>self>otherSelf',
+              ],
+            },
           ],
           override: {
             maxDepth: 11,

--- a/src/DepthVisitor.ts
+++ b/src/DepthVisitor.ts
@@ -15,7 +15,6 @@ import {
   Kind,
 } from "graphql";
 
-import { ErrorOperationLocation } from "./interfaces.js";
 import { RuleError } from "./ruleError.js";
 import type { RulesContext } from "./rulesContext.js";
 

--- a/src/OperationPathsVisitor.ts
+++ b/src/OperationPathsVisitor.ts
@@ -1,0 +1,14 @@
+import { type ASTVisitor, Kind } from "graphql";
+
+import type { RulesContext } from "./rulesContext";
+
+export function OperationPathsVisitor(context: RulesContext): ASTVisitor {
+  return {
+    enter(node) {
+      context.initEnterNode(node);
+    },
+    leave(node) {
+      context.initLeaveNode(node);
+    },
+  };
+}

--- a/src/OperationPathsVisitor.ts
+++ b/src/OperationPathsVisitor.ts
@@ -1,4 +1,4 @@
-import { type ASTVisitor, Kind } from "graphql";
+import type { ASTVisitor } from "graphql";
 
 import type { RulesContext } from "./rulesContext";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import "graphile-config";
 import { CallbackOrDescriptor, MiddlewareNext } from "graphile-config";
-import { CheckDocumentEvent, CheckDocumentOutput } from "./interfaces.js";
+import {
+  CheckDocumentEvent,
+  CheckDocumentOutput,
+  CreateVisitorEvent,
+  VisitorsEvent,
+} from "./interfaces.js";
+import { ASTVisitor } from "graphql";
 
 export { filterBaseline, generateBaseline } from "./baseline.js";
 export {
@@ -56,6 +62,8 @@ declare global {
       checkDocument(
         event: CheckDocumentEvent,
       ): PromiseLike<CheckDocumentOutput>;
+      visitors(event: VisitorsEvent): PromiseOrDirect<ASTVisitor[]>;
+      createVisitor(event: CreateVisitorEvent): PromiseOrDirect<ASTVisitor>;
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import type { CallbackOrDescriptor, MiddlewareNext } from "graphile-config";
-import type { ASTVisitor } from "graphql";
+import type { ASTVisitor, GraphQLError } from "graphql";
 
 import type {
   CheckDocumentEvent,
   CheckDocumentOutput,
   CreateVisitorEvent,
+  ValidateEvent,
   VisitorsEvent,
 } from "./interfaces.js";
 
@@ -61,6 +62,9 @@ declare global {
     }
 
     interface GqlcheckMiddleware {
+      validate(
+        event: ValidateEvent,
+      ): PromiseOrDirect<ReadonlyArray<GraphQLError>>;
       checkDocument(
         event: CheckDocumentEvent,
       ): PromiseLike<CheckDocumentOutput>;
@@ -69,6 +73,5 @@ declare global {
     }
   }
 }
-
 export type PromiseOrDirect<T> = PromiseLike<T> | T;
 export type TruePromiseOrDirect<T> = Promise<T> | T;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import "graphile-config";
-import { CallbackOrDescriptor, MiddlewareNext } from "graphile-config";
-import {
+import type { CallbackOrDescriptor, MiddlewareNext } from "graphile-config";
+import type { ASTVisitor } from "graphql";
+
+import type {
   CheckDocumentEvent,
   CheckDocumentOutput,
   CreateVisitorEvent,
   VisitorsEvent,
 } from "./interfaces.js";
-import { ASTVisitor } from "graphql";
 
 export { filterBaseline, generateBaseline } from "./baseline.js";
 export {
@@ -17,6 +17,8 @@ export {
 } from "./interfaces.js";
 export { checkOperations } from "./main.js";
 export { printResults } from "./print.js";
+export { RuleError } from "./ruleError.js";
+export { RulesContext } from "./rulesContext.js";
 
 declare global {
   namespace GraphileConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import "graphile-config";
+import { CallbackOrDescriptor, MiddlewareNext } from "graphile-config";
+import { CheckDocumentEvent, CheckDocumentOutput } from "./interfaces.js";
+
 export { filterBaseline, generateBaseline } from "./baseline.js";
 export {
   Baseline,
@@ -21,6 +25,7 @@ declare global {
         config?: GraphileConfig.GraphQLCheckConfig;
       };
     }
+
     interface GraphQLCheckConfig {
       maxDepth?: number;
       maxListDepth?: number;
@@ -32,5 +37,28 @@ declare global {
         [fieldCoordinate: string]: number;
       };
     }
+
+    interface Plugin {
+      gqlcheck?: {
+        middleware?: {
+          [key in keyof GqlcheckMiddleware]?: CallbackOrDescriptor<
+            GqlcheckMiddleware[key] extends (
+              ...args: infer UArgs
+            ) => infer UResult
+              ? (next: MiddlewareNext<UResult>, ...args: UArgs) => UResult
+              : never
+          >;
+        };
+      };
+    }
+
+    interface GqlcheckMiddleware {
+      checkDocument(
+        event: CheckDocumentEvent,
+      ): PromiseLike<CheckDocumentOutput>;
+    }
   }
 }
+
+export type PromiseOrDirect<T> = PromiseLike<T> | T;
+export type TruePromiseOrDirect<T> = Promise<T> | T;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -59,3 +59,7 @@ export interface Baseline {
       | undefined;
   };
 }
+
+export interface CheckDocumentEvent {
+  req: CheckDocumentRequest;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -38,8 +38,10 @@ export interface SourceResultsBySourceName {
 
 export interface RuleFormattedError extends GraphQLFormattedError {
   infraction: string;
-  operationNames: ReadonlyArray<string | undefined>;
-  operationCoordinates: ReadonlyArray<string>;
+  operations: ReadonlyArray<{
+    operationName: string | undefined;
+    operationCoordinates: ReadonlyArray<string>;
+  }>;
   override: GraphileConfig.GraphQLCheckConfig;
 }
 
@@ -73,4 +75,8 @@ export interface VisitorsEvent {
 export interface CreateVisitorEvent {
   rulesContext: RulesContext;
   visitors: ASTVisitor[];
+}
+export interface ErrorOperationLocation {
+  operationName: string | undefined;
+  operationCoordinates: string[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,11 @@
-import type { ASTVisitor, GraphQLFormattedError } from "graphql";
+import type {
+  ASTVisitor,
+  DocumentNode,
+  GraphQLFormattedError,
+  GraphQLSchema,
+  validate,
+  ValidationRule,
+} from "graphql";
 
 import type { RulesContext } from "./rulesContext";
 
@@ -78,4 +85,14 @@ export interface CreateVisitorEvent {
 export interface ErrorOperationLocation {
   operationName: string | undefined;
   operationCoordinates: string[];
+}
+export interface ValidateEvent {
+  validate: typeof validate;
+  schema: GraphQLSchema;
+  document: DocumentNode;
+  rulesContext: RulesContext;
+  validationRules: ValidationRule[];
+  options: {
+    maxErrors?: number;
+  };
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor, GraphQLFormattedError } from "graphql";
 
-import { TypeAndOperationPathInfo } from "./operationPaths";
 import type { RulesContext } from "./rulesContext";
 
 export interface WorkerData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,5 @@
-import type { GraphQLFormattedError } from "graphql";
+import type { ASTVisitor, GraphQLFormattedError } from "graphql";
+import { TypeAndOperationPathInfo } from "./operationPaths";
 
 export interface WorkerData {
   configPath: string | null | undefined;
@@ -62,4 +63,12 @@ export interface Baseline {
 
 export interface CheckDocumentEvent {
   req: CheckDocumentRequest;
+}
+export interface VisitorsEvent {
+  typeInfo: TypeAndOperationPathInfo;
+  visitors: ASTVisitor[];
+}
+export interface CreateVisitorEvent {
+  typeInfo: TypeAndOperationPathInfo;
+  visitors: ASTVisitor[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,7 @@
 import type { ASTVisitor, GraphQLFormattedError } from "graphql";
+
 import { TypeAndOperationPathInfo } from "./operationPaths";
+import type { RulesContext } from "./rulesContext";
 
 export interface WorkerData {
   configPath: string | null | undefined;
@@ -36,8 +38,8 @@ export interface SourceResultsBySourceName {
 
 export interface RuleFormattedError extends GraphQLFormattedError {
   infraction: string;
-  operationName: string | undefined;
-  operationCoordinates: string[];
+  operationNames: ReadonlyArray<string | undefined>;
+  operationCoordinates: ReadonlyArray<string>;
   override: GraphileConfig.GraphQLCheckConfig;
 }
 
@@ -65,10 +67,10 @@ export interface CheckDocumentEvent {
   req: CheckDocumentRequest;
 }
 export interface VisitorsEvent {
-  typeInfo: TypeAndOperationPathInfo;
+  rulesContext: RulesContext;
   visitors: ASTVisitor[];
 }
 export interface CreateVisitorEvent {
-  typeInfo: TypeAndOperationPathInfo;
+  rulesContext: RulesContext;
   visitors: ASTVisitor[];
 }

--- a/src/print.ts
+++ b/src/print.ts
@@ -20,7 +20,8 @@ function printGraphQLFormattedError(error: GraphQLFormattedError) {
   return `${printGraphQLFormattedErrorLocations(error)}${error.message}`;
 }
 function printRuleFormattedError(error: RuleFormattedError) {
-  return `${printGraphQLFormattedErrorLocations(error)}${error.message}\nProblematic paths:\n- ${error.operationCoordinates.slice(0, 10).join("\n- ")}${error.operationCoordinates.length > 10 ? "\n- ..." : ""}`;
+  const opCoords = error.operations.flatMap((o) => o.operationCoordinates);
+  return `${printGraphQLFormattedErrorLocations(error)}${error.message}\nProblematic paths:\n- ${opCoords.slice(0, 10).join("\n- ")}${opCoords.length > 10 ? "\n- ..." : ""}`;
 }
 
 export function printResults(result: CheckOperationsResult, _detailed = false) {

--- a/src/ruleError.ts
+++ b/src/ruleError.ts
@@ -1,7 +1,7 @@
 import type { GraphQLErrorOptions } from "graphql";
 import { formatError, GraphQLError, version as GraphQLVersion } from "graphql";
 
-import type { RuleFormattedError } from "./interfaces";
+import type { ErrorOperationLocation, RuleFormattedError } from "./interfaces";
 import type { RulesContext } from "./rulesContext";
 
 const graphqlMajor = parseInt(GraphQLVersion.split(".")[0], 10);
@@ -10,6 +10,7 @@ export interface RuleErrorOptions extends GraphQLErrorOptions {
   infraction: string;
   /** What needs to be added to the overrides for this coordinate for this error to be ignored? */
   override: GraphileConfig.GraphQLCheckConfig;
+  errorOperationLocations?: readonly ErrorOperationLocation[];
 }
 
 export class RuleError extends GraphQLError {
@@ -34,7 +35,9 @@ export class RuleError extends GraphQLError {
     return {
       ...(super.toJSON?.() ?? formatError(this)),
       infraction: this.options.infraction,
-      ...context.getOperationNamesAndCoordinatesForNodes(this.nodes),
+      operations:
+        this.options.errorOperationLocations ??
+        context.getErrorOperationLocationsForNodes(this.nodes),
       override: this.options.override,
     };
   }

--- a/src/ruleError.ts
+++ b/src/ruleError.ts
@@ -2,13 +2,12 @@ import type { GraphQLErrorOptions } from "graphql";
 import { formatError, GraphQLError, version as GraphQLVersion } from "graphql";
 
 import type { RuleFormattedError } from "./interfaces";
+import type { RulesContext } from "./rulesContext";
 
 const graphqlMajor = parseInt(GraphQLVersion.split(".")[0], 10);
 
 export interface RuleErrorOptions extends GraphQLErrorOptions {
   infraction: string;
-  operationName: string | undefined;
-  operationCoordinates: string[];
   /** What needs to be added to the overrides for this coordinate for this error to be ignored? */
   override: GraphileConfig.GraphQLCheckConfig;
 }
@@ -31,12 +30,11 @@ export class RuleError extends GraphQLError {
     }
     Object.defineProperty(this, "options", { value: options });
   }
-  toJSON(): RuleFormattedError {
+  toJSONEnhanced(context: RulesContext): RuleFormattedError {
     return {
       ...(super.toJSON?.() ?? formatError(this)),
       infraction: this.options.infraction,
-      operationName: this.options.operationName,
-      operationCoordinates: this.options.operationCoordinates,
+      ...context.getOperationNamesAndCoordinatesForNodes(this.nodes),
       override: this.options.override,
     };
   }

--- a/src/rulesContext.ts
+++ b/src/rulesContext.ts
@@ -1,5 +1,13 @@
-import type { DocumentNode, GraphQLError, GraphQLSchema } from "graphql";
-import { ValidationContext } from "graphql";
+import type {
+  ASTNode,
+  DocumentNode,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+  GraphQLError,
+  GraphQLSchema,
+  OperationDefinitionNode,
+} from "graphql";
+import { Kind, ValidationContext } from "graphql";
 
 import type { TypeAndOperationPathInfo } from "./operationPaths";
 import type { RuleError } from "./ruleError";
@@ -14,6 +22,9 @@ export class RulesContext extends ValidationContext {
   ) {
     super(schema, ast, typeInfo, (error) => onError(error));
   }
+  getTypeInfo() {
+    return this.typeInfo;
+  }
   getOperationPath() {
     return this.typeInfo.getOperationPath();
   }
@@ -22,5 +33,124 @@ export class RulesContext extends ValidationContext {
   }
   isIntrospection() {
     return this.typeInfo.isIntrospection();
+  }
+  operationPathByNode = new Map<ASTNode, string>();
+  operationNamesByNode = new Map<ASTNode, Array<string | undefined>>();
+
+  _fragmentsByRoot = new Map<
+    FragmentDefinitionNode | OperationDefinitionNode,
+    FragmentSpreadNode[]
+  >();
+  _nodesByRoot = new Map<
+    FragmentDefinitionNode | OperationDefinitionNode,
+    Array<ASTNode>
+  >();
+  _operationDefinitions: OperationDefinitionNode[] = [];
+  _fragmentDefinitions: FragmentDefinitionNode[] = [];
+  initEnterNode(node: ASTNode) {
+    const root = this.typeInfo.getCurrentRoot();
+    if (root != null) {
+      let list = this._nodesByRoot.get(root);
+      if (!list) {
+        list = [];
+        this._nodesByRoot.set(root, list);
+      }
+      list.push(node);
+    }
+    if (node.kind === Kind.OPERATION_DEFINITION) {
+      this._operationDefinitions.push(node);
+    }
+    if (node.kind === Kind.FRAGMENT_DEFINITION) {
+      this._fragmentDefinitions.push(node);
+    }
+    if (node.kind === Kind.FRAGMENT_SPREAD) {
+      if (!this.typeInfo.currentRoot) {
+        throw new Error(
+          "Cannot have a fragment spread without being inside a fragment definition/operation",
+        );
+      }
+      let list = this._fragmentsByRoot.get(this.typeInfo.currentRoot);
+      if (!list) {
+        list = [];
+        this._fragmentsByRoot.set(this.typeInfo.currentRoot, list);
+      }
+      list.push(node);
+    }
+    this.operationPathByNode.set(node, this.typeInfo.getOperationPath());
+  }
+  initLeaveNode(node: ASTNode) {
+    if (node.kind === Kind.DOCUMENT) {
+      // Finalize
+      for (const operationDefinition of this._operationDefinitions) {
+        const operationName = operationDefinition.name?.value;
+        const walk = (
+          root: OperationDefinitionNode | FragmentDefinitionNode,
+          visited: Set<OperationDefinitionNode | FragmentDefinitionNode>,
+        ) => {
+          // This runs before we've ensured there's no cycles, so we must protect ourself
+          if (visited.has(root)) {
+            return;
+          }
+          visited.add(root);
+          // Every node in this root is within operationName
+          const nodes = this._nodesByRoot.get(root);
+          if (nodes) {
+            for (const node of nodes) {
+              let list = this.operationNamesByNode.get(node);
+              if (!list) {
+                list = [];
+                this.operationNamesByNode.set(node, list);
+              }
+              list.push(operationName);
+            }
+          }
+          const fragSpreads = this._fragmentsByRoot.get(root);
+          if (fragSpreads) {
+            for (const fragSpread of fragSpreads) {
+              const frag = this._fragmentDefinitions.find(
+                (d) => d.name.value === fragSpread.name.value,
+              );
+              if (frag) {
+                walk(frag, visited);
+              }
+            }
+          }
+          visited.delete(root);
+        };
+        walk(operationDefinition, new Set());
+      }
+    }
+  }
+  getOperationNamesAndCoordinatesForNodes(
+    nodes: readonly ASTNode[] | undefined,
+  ): {
+    operationNames: readonly (string | undefined)[];
+    operationCoordinates: string[];
+  } {
+    if (nodes == null) {
+      console.log(`No nodes!`);
+      return {
+        operationNames: [],
+        operationCoordinates: [],
+      };
+    }
+    const operationNames = new Set<string | undefined>();
+    const operationCoordinates = new Set<string>();
+    for (const node of nodes) {
+      const nodeOperationNames = this.operationNamesByNode.get(node);
+      if (nodeOperationNames) {
+        for (const operationName of nodeOperationNames) {
+          operationNames.add(operationName);
+        }
+      }
+      const nodeOperationCoordinate = this.operationPathByNode.get(node);
+      if (nodeOperationCoordinate) {
+        operationCoordinates.add(nodeOperationCoordinate);
+      }
+    }
+    return {
+      operationNames: [...operationNames],
+      operationCoordinates: [...operationCoordinates],
+    };
   }
 }

--- a/src/rulesContext.ts
+++ b/src/rulesContext.ts
@@ -147,8 +147,14 @@ export class RulesContext extends ValidationContext {
       }
     }
   }
+  getOperationNamesForNodes(nodes: readonly ASTNode[] | undefined) {
+    return nodes
+      ? nodes.flatMap((node) => this.operationNamesByNode.get(node) ?? [])
+      : [];
+  }
   getErrorOperationLocationsForNodes(
     nodes: readonly ASTNode[] | undefined,
+    limitToOperations?: ReadonlyArray<string | undefined>,
   ): ReadonlyArray<ErrorOperationLocation> {
     if (nodes == null) {
       return [];
@@ -158,6 +164,9 @@ export class RulesContext extends ValidationContext {
       const nodeOperationNames = this.operationNamesByNode.get(node);
       if (nodeOperationNames) {
         for (const operationName of nodeOperationNames) {
+          if (limitToOperations && !limitToOperations.includes(operationName)) {
+            continue;
+          }
           let set = map.get(operationName);
           if (!set) {
             set = new Set();

--- a/src/rulesContext.ts
+++ b/src/rulesContext.ts
@@ -7,6 +7,7 @@ import type {
   GraphQLSchema,
   OperationDefinitionNode,
 } from "graphql";
+import * as graphqlLibrary from "graphql";
 import { Kind, ValidationContext } from "graphql";
 
 import type { ErrorOperationLocation } from "./interfaces";
@@ -14,6 +15,7 @@ import type { TypeAndOperationPathInfo } from "./operationPaths";
 import type { RuleError } from "./ruleError";
 
 export class RulesContext extends ValidationContext {
+  graphqlLibrary = graphqlLibrary;
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -99,6 +99,7 @@ async function main() {
       errors.push(
         error.toJSONEnhanced?.(rulesContext) ??
           error.toJSON?.() ??
+          // Ignore deprecated, this is for GraphQL v15 support
           formatError(error),
       );
     }
@@ -126,7 +127,12 @@ async function main() {
       return {
         sourceName,
         operations: [],
-        errors: validationErrors.map((e) => e.toJSON?.() ?? formatError(e)),
+        errors: validationErrors.map(
+          (e) =>
+            e.toJSON?.() ??
+            // Ignore deprecated, this is for GraphQL v15 support
+            formatError(e),
+        ),
       };
     }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -117,10 +117,6 @@ async function main() {
     const validationRules = [...specifiedRules];
     const mode =
       graphqlVersionMajor === 15 ? 1 : graphqlVersionMajor === 16 ? 2 : 0;
-    if (mode > 0) {
-      // We need to run this so we know what the operation path/operation names are for rule errors.
-      validationRules.push(() => OperationPathsVisitor(rulesContext));
-    }
 
     const validationErrors = await middleware.run(
       "validate",
@@ -145,7 +141,7 @@ async function main() {
             validate(
               schema,
               document,
-              validationRules,
+              [...validationRules, () => OperationPathsVisitor(rulesContext)],
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               typeInfo as any,
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -156,7 +152,7 @@ async function main() {
               validate(
                 schema,
                 document,
-                validationRules,
+                [...validationRules, () => OperationPathsVisitor(rulesContext)],
                 options,
                 rulesContext.getTypeInfo(),
               )

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -174,7 +174,7 @@ async function main() {
     }
 
     if (mode === 0) {
-      // Need to revisit
+      // Need to revisit, because OperationPathsVisitor didn't run above.
       visit(
         document,
         visitWithTypeInfo(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -129,7 +129,9 @@ async function main() {
             schema,
             document,
             baseValidationRules,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             typeInfo as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             {} as any,
           )
         : mode === 2

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -111,8 +111,18 @@ async function main() {
       config,
       onError,
     );
-    const visitor = visitInParallel([DepthVisitor(rulesContext)]);
-    visit(document, visitWithTypeInfo(typeInfo, visitor));
+    const visitors = await middleware.run(
+      "visitors",
+      { typeInfo, visitors: [DepthVisitor(rulesContext)] },
+      ({ visitors }) => visitors,
+    );
+    const visitor = await middleware.run(
+      "createVisitor",
+      { typeInfo, visitors },
+      ({ typeInfo, visitors }) =>
+        visitWithTypeInfo(typeInfo, visitInParallel(visitors)),
+    );
+    visit(document, visitor);
 
     const operations = operationDefinitions.map(
       (operationDefinition): CheckDocumentOperationResult => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -60,6 +60,7 @@ async function main() {
     config.plugins,
     (p) => p.gqlcheck?.middleware,
     (name, fn, _plugin) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       middleware.register(name, fn as any);
     },
   );


### PR DESCRIPTION
## Description

Add your own validations via a plugin system.

`src/index.ts`:
```ts
import type {} from "gqlcheck";
import { MyPlugin } from "./plugin.js";

declare global {
  namespace GraphileConfig {
    interface GraphQLCheckConfig {
      /** Description here */
      mySetting?: boolean;
    }
  }
}

export const MyPreset: GraphileConfig.Preset = {
  plugins: [MyPlugin],
};
```

`src/plugin.ts`:
```ts
import type {} from "gqlcheck";
import { MyVisitor } from "./MyVisitor.js";

export const MyPlugin: GraphileConfig.Plugin = {
  name: "MyPlugin",
  version: "0.0.0",
  gqlcheck: {
    middleware: {
      visitors(next, event) {
        event.visitors.push(MyVisitor(event.rulesContext));
        return next();
      },
    },
  },
};
```

`src/MyVisitor.ts`:
```ts
import { RuleError, type RulesContext } from "gqlcheck";
import type { ASTVisitor } from "graphql";

export function MyVisitor(context: RulesContext): ASTVisitor {
  // Extract configuration.
  const {
    gqlcheck: {
      config: { mySetting = true } = {},
      operationOverrides = Object.create(null),
    } = {},
  } = context.getResolvedPreset();
  return {
    Field(node) {
      // Get GraphQL stuff from here rather than `import` to avoid conflicts
      const { isListType, getNullableType } = context.graphqlLibrary;
      const fieldDef = context.getFieldDef();

      const nodes = [node];
      // A node may be used in more than one operation.
      const allOperationNames = context.getOperationNamesForNodes(nodes);
      // Filter to just the operations where this setting is enabled.
      const operationNames = allOperationNames.filter(
        (n) =>
          // Can only use operationOverrides if the operation is named.
          (n ? operationOverrides[n]?.mySetting : null) ?? mySetting,
      );
      // Find the locations where the setting is enabled.
      const ops = context.getErrorOperationLocationsForNodes(
        nodes,
        operationNames,
      );

      // Only report if there are locations where the setting is enabled.
      if (ops.length > 0) {
        // Nonsense rule, demonstration purposes only. Forbids lists.
        const isList = isListType(getNullableType(fieldDef.type));
        if (isList) {
          context.reportError(
            new RuleError(`Querying lists is not allowed!`, {
              // Typically this will be the name of the setting.
              infraction: `mySetting`,
              nodes,
              errorOperationLocations: ops,
              // If the user merges this override in for this operation, the
              // error should go away.
              override: {
                mySetting: false,
              },
            }),
          );
        }
      }
    },
  };
}
```


## Performance impact

Overhead, but worthwhile.

## Security impact

You can now use arbitrary third party plugins... Only use plugins you trust.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
