### PR TITLE
Sort baselines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   filterBaseline,
   filterOnlyErrors,
   generateBaseline,
+  sortBaseline,
 } from "./baseline.js";
 export {
   Baseline,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -68,17 +68,21 @@ export interface CheckOperationsResult {
   filtered: number;
 }
 
+export interface BaselineOperationsIgnoreCoordinatesByRule {
+  [infraction: string]: string[] | undefined;
+}
+
+export interface BaselineOperations {
+  [operationName: string]:
+    | {
+        ignoreCoordinatesByRule: BaselineOperationsIgnoreCoordinatesByRule;
+      }
+    | undefined;
+}
+
 export interface Baseline {
   version: 1;
-  operations: {
-    [operationName: string]:
-      | {
-          ignoreCoordinatesByRule: {
-            [infraction: string]: string[] | undefined;
-          };
-        }
-      | undefined;
-  };
+  operations: BaselineOperations;
 }
 
 export interface CheckDocumentEvent {


### PR DESCRIPTION
Fixes #9 - by sorting the baselines, updating a baseline should be a smaller diff.